### PR TITLE
vsProcessID + fix initial replace of all text in pattern editor

### DIFF
--- a/RenameVSWindowTitle/EditablePatternControl.cs
+++ b/RenameVSWindowTitle/EditablePatternControl.cs
@@ -24,6 +24,8 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
             get { return this.txEdit.Text; }
             set {
                 this.txEdit.Text = value;
+                this.txEdit.Focus();
+                this.txEdit.Select(this.txEdit.Text.Length, 0); // set insert point to the end
                 this.updatePreview();
 
             }
@@ -47,6 +49,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
 
         private void setToDefault_Click(object sender, EventArgs e) {
             this.txEdit.Text = this.DefaultPattern;
+            this.txEdit.Select(this.txEdit.Text.Length, 0); // set insert point to the end
         }
 
         private void insertTag_Click(object sender, EventArgs e) {

--- a/RenameVSWindowTitle/RenameVSWindowTitlePackage.cs
+++ b/RenameVSWindowTitle/RenameVSWindowTitlePackage.cs
@@ -434,7 +434,8 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
             "gitBranchName",
             "hgBranchName",
             "workspaceName",
-            "workspaceOwnerName"
+            "workspaceOwnerName",
+            "vsProcessID"
         };
 
         readonly Regex TagRegex = new Regex(@"\[([^\[\]]+)\]", RegexOptions.Multiline | RegexOptions.Compiled);
@@ -517,6 +518,8 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                                 return Globals.VsMajorVersion.ToString(CultureInfo.InvariantCulture);
                             case "vsMajorVersionYear":
                                 return Globals.VsMajorVersionYear.ToString(CultureInfo.InvariantCulture);
+                            case "vsProcessID":
+                                return System.Diagnostics.Process.GetCurrentProcess().Id.ToString();
                             case "ideName":
                                 return this.IDEName ?? string.Empty;
                             case "path":

--- a/RenameVSWindowTitle/Resources.Designer.cs
+++ b/RenameVSWindowTitle/Resources.Designer.cs
@@ -83,7 +83,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
         ///}
         ///
         ////* HTML5 display definitions
-        ///   ============== [rest of string was truncated]&quot;;.
+        ///   ==================================== [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string normalize {
             get {
@@ -351,6 +351,15 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
         internal static string tag_vsMajorVersionYear {
             get {
                 return ResourceManager.GetString("tag_vsMajorVersionYear", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Process-ID of Visual Studio.
+        /// </summary>
+        internal static string tag_vsProcessID {
+            get {
+                return ResourceManager.GetString("tag_vsProcessID", resourceCulture);
             }
         }
         

--- a/RenameVSWindowTitle/Resources.resx
+++ b/RenameVSWindowTitle/Resources.resx
@@ -196,6 +196,9 @@
   <data name="tag_vsMajorVersionYear" xml:space="preserve">
     <value>Major version of Visual Studio, in year form (e.g. 2008, 2010, 2012, 2013, 2015...).</value>
   </data>
+  <data name="tag_vsProcessID" xml:space="preserve">
+    <value>Process-ID of Visual Studio</value>
+  </data>
   <data name="tag_workspaceName" xml:space="preserve">
     <value>Current Team Foundation Server (TFS) workspace name.</value>
   </data>


### PR DESCRIPTION
added vsProcessID (visual studio process id) to substitutions (usefull for killing a specific VS instance)
set insert postition to the end in pattern editor (fixes full replace when inserting)
