### PR TITLE
Added subversion directory resolver

### DIFF
--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitle.csproj
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitle.csproj
@@ -7,6 +7,9 @@
     </NuGetPackageImportStamp>
     <UseCodebase>true</UseCodebase>
     <TargetFrameworkProfile />
+	<StartAction>Program</StartAction>
+	<StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+	<StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -63,6 +66,7 @@
     <Compile Include="Resolvers\PathResolver.cs" />
     <Compile Include="Resolvers\ProjectResolver.cs" />
     <Compile Include="Resolvers\SolutionResolver.cs" />
+    <Compile Include="Resolvers\SvnResolver.cs" />
     <Compile Include="Resolvers\TagResolver.cs" />
     <Compile Include="Resolvers\TfsWorkspaceResolver.cs" />
     <None Include="Lib\TeamFoundationHelper.cs" />

--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
@@ -81,6 +81,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new ConfigurationNameResolver(),
                 new GitBranchNameResolver(),
                 new HgBranchNameResolver(),
+                new SvnDirectoryResolver(),
                 new WorkspaceNameResolver(),
                 new WorkspaceOwnerNameResolver(),
                 new VsProcessIdResolver(),

--- a/CustomizeVSWindowTitle/GlobalSettingsPageGrid.cs
+++ b/CustomizeVSWindowTitle/GlobalSettingsPageGrid.cs
@@ -90,6 +90,14 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
         [DefaultValue("")]
         public string HgDirectory { get; set; } = "";
 
+        [Category("Source control")]
+        [DisplayName("Svn binaries directory")]
+        [Description("Default: Empty. Search windows PATH for svn if empty.")]
+        [Editor(typeof(FilePickerEditor), typeof(System.Drawing.Design.UITypeEditor))]
+        [FilePicker(true, SvnDirectoryResolver.SvnExecFn, "Svn executable(svn.exe)|svn.exe|All files(*.*)|*.*", 1)]
+        [DefaultValue("")]
+        public string SvnDirectory { get; set; } = "";
+
         [Category("Debug")]
         [DisplayName("Enable debug mode")]
         [Description("Default: false. Set to true to activate debug output to Output window.")]

--- a/CustomizeVSWindowTitle/Resolvers/SvnResolver.cs
+++ b/CustomizeVSWindowTitle/Resolvers/SvnResolver.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using EnvDTE;
+
+namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers
+{
+    public class SvnDirectoryResolver : SimpleTagResolver {
+
+        public const string SvnExecFn = "svn.exe";
+        private static string SvnExecFp = SvnExecFn;
+
+        public SvnDirectoryResolver() : base(tagName: "svnDirectory") { }
+
+        public override string Resolve(AvailableInfo info) {
+            UpdateSvnExecFp(info.GlobalSettings.SvnDirectory);
+            return GetSvnDirectoryOrEmpty(info.Solution);
+        }
+        public static void UpdateSvnExecFp(string svnDp)
+        {
+            if (string.IsNullOrEmpty(svnDp))
+            {
+                SvnExecFp = SvnExecFn;
+                return;
+            }
+            SvnExecFp = Path.Combine(svnDp, SvnExecFn);
+        }
+
+        public static string GetSvnDirectoryOrEmpty(Solution solution) {
+            var sn = solution?.FullName;
+            if (string.IsNullOrEmpty(sn)) return string.Empty;
+            var workingDirectory = new FileInfo(sn).DirectoryName;
+            return etSvnDirectory(workingDirectory) ?? string.Empty;
+        }
+
+        public static string etSvnDirectory(string workingDirectory) {
+            try
+            {
+                using (var pProcess = new System.Diagnostics.Process
+                {
+                    StartInfo =
+                    {
+                        FileName = SvnExecFp,
+                        Arguments = "info",
+                        UseShellExecute = false,
+                        StandardOutputEncoding = Encoding.UTF8,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true,
+                        WorkingDirectory = workingDirectory
+                    }
+                })
+                {
+                    pProcess.Start();
+                    string output = pProcess.StandardOutput.ReadToEnd();
+                    pProcess.WaitForExit();
+                    if (pProcess.ExitCode != 0)
+                    {
+                        // Not a working directory.
+                        return null;
+                    }
+                    const string Prefix = "Relative URL: ";
+                    string branchLine = output.Split('\n').SingleOrDefault(line => line.StartsWith(Prefix, StringComparison.Ordinal));
+                    if (branchLine != null)
+                        return branchLine.Substring(Prefix.Length).Trim('^', '\n', '\r', ' ');
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                try
+                {
+                    if (CustomizeVSWindowTitle.CurrentPackage.UiSettings.EnableDebugMode)
+                    {
+                        CustomizeVSWindowTitle.WriteOutput("svnDirectoryResolver.GetSvnBranch() exception: " + ex);
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Svn directory resolver similar to the git/hg branch resolver. I'm calling it "directory" because it is just a folder in the remote repo where the sln file is,  not an explicit branch name as in the case of git. It will usually be e.g. /trunk/Source/MyProject or similar.

There are now 3 very similar resolvers for git/svn/hg so should probably be a shared base class for resolvers that execute a command line tool and return a string. I opted against doing that refactoring in this PR.

Hope you don't mind I added the "standard" properties for vsix debugging to the .csproj. Makes it more contributor friendly becasuse you can clone the repo and debug the vsix directly (Without the props in csproj, each developer has to set the same in the csproj properties because it's only stored in the .csproj.user file).

