### PR TITLE
Add indexes to the svn directory tag

### DIFF
--- a/CustomizeVSWindowTitle/GlobalSettingsPageGrid.cs
+++ b/CustomizeVSWindowTitle/GlobalSettingsPageGrid.cs
@@ -98,6 +98,12 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
         [DefaultValue("")]
         public string SvnDirectory { get; set; } = "";
 
+        [Category("Source control")]
+        [DisplayName("Svn directory separator")]
+        [Description("Default: '/'. Specify the character used to separate the svn directories.")]
+        [DefaultValue("/")]
+        public string SvnDirectorySeparator { get; set; } = "/";
+
         [Category("Debug")]
         [DisplayName("Enable debug mode")]
         [Description("Default: false. Set to true to activate debug output to Output window.")]

--- a/CustomizeVSWindowTitle/Properties/Resources.Designer.cs
+++ b/CustomizeVSWindowTitle/Properties/Resources.Designer.cs
@@ -391,6 +391,24 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Svn directory element at the specified index (e.g. for /Branches/Developer/UserName/MySolutionFolder/MySolution.sln, [path:0] = /, [path:1] = Branches).
+        /// </summary>
+        internal static string tag_svnDirectoryNameX {
+            get {
+                return ResourceManager.GetString("tag_svnDirectoryNameX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Svn directory segment over the specified range (e.g. for  /Branches/Developer/UserName/MySolutionFolder/MySolution.sln, [path:0:2] = /Branches/Developer, [path:2:0] = Developer/Branches//).
+        /// </summary>
+        internal static string tag_svnDirectoryNameXY {
+            get {
+                return ResourceManager.GetString("tag_svnDirectoryNameXY", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Major version of Visual Studio (e.g. 11, 12, 14, 15...)..
         /// </summary>
         internal static string tag_vsMajorVersion {

--- a/CustomizeVSWindowTitle/Properties/Resources.resx
+++ b/CustomizeVSWindowTitle/Properties/Resources.resx
@@ -208,6 +208,12 @@
   <data name="tag_svnDirectoryName" xml:space="preserve">
     <value>Current SVN directory name. Make sure SVN's executable directory is added to the Windows PATH variable or specify its location in settings.</value>
   </data>
+  <data name="tag_svnDirectoryNameX" xml:space="preserve">
+    <value>Svn directory element at the specified index (e.g. for /Branches/Developer/UserName/MySolutionFolder/MySolution.sln, [path:0] = /, [path:1] = Branches)</value>
+  </data>
+  <data name="tag_svnDirectoryNameXY" xml:space="preserve">
+    <value>Svn directory segment over the specified range (e.g. for  /Branches/Developer/UserName/MySolutionFolder/MySolution.sln, [path:0:2] = /Branches/Developer, [path:2:0] = Developer/Branches//)</value>
+  </data>
   <data name="tag_vsMajorVersion" xml:space="preserve">
     <value>Major version of Visual Studio (e.g. 11, 12, 14, 15...).</value>
   </data>

--- a/CustomizeVSWindowTitle/Resolvers/SvnResolver.cs
+++ b/CustomizeVSWindowTitle/Resolvers/SvnResolver.cs
@@ -27,11 +27,13 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
         public override bool TryResolve(string tag, AvailableInfo info, out string s) {
             s = null;
             if (!tag.StartsWith(tagName, StringComparison.InvariantCulture)) return false;
-
             var svnPath = Resolve(info);
             if (string.IsNullOrWhiteSpace(svnPath)) return false;
-            var svnPathParts = new List<string> { "/" }; // Initialize with a root
-            svnPathParts.AddRange(svnPath.Split(new[] { System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries));
+            var directorySeparator = info.GlobalSettings.SvnDirectorySeparator;
+            var svnPathParts = new List<string>();
+            if (Path.IsPathRooted(svnPath))
+                svnPathParts.Add(directorySeparator);
+            svnPathParts.AddRange(svnPath.Split(new[] { directorySeparator }, StringSplitOptions.RemoveEmptyEntries));
             var m = Globals.RangeRegex.Match(tag.Substring(tagName.Length));
             if (m.Success) {
                 if (!svnPathParts.Any()) {
@@ -41,7 +43,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
                     var startIndex = Math.Min(svnPathParts.Count - 1, Math.Max(0, int.Parse(m.Groups["startIndex"].Value, CultureInfo.InvariantCulture)));
                     var endIndex = Math.Min(svnPathParts.Count - 1, Math.Max(0, int.Parse(m.Groups["endIndex"].Value, CultureInfo.InvariantCulture)));
                     var pathRange = svnPathParts.GetRange(startIndex: startIndex, endIndex: endIndex).ToArray();
-                    s = Globals.GetPathForTitle(pathRange);
+                    s = string.Join(directorySeparator, pathRange);
                 }
                 return true;
             }


### PR DESCRIPTION
I've added the ability to use indexes on the svnDirectoryName. 
They follow the same pattern as the path tag, that is, it supports svnDirectoryName, svnDirectoryName:X, and svnDirectoryName:X:Y. 

I also added the option for the user to specify the directory separator used in their svn repo if needed.