### PR TITLE
Cleaning up the startupProjectNames. Removing relative path from the …

### DIFF
--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
@@ -48,6 +48,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new DocumentNameResolver(),
                 new ProjectNameResolver(),
                 new StartupProjectNamesResolver(),
+                new StartupProjectNamesNonRelativeResolver(),
                 new DocumentProjectNameResolver(),
                 new DocumentProjectFileNameResolver(),
                 new SolutionNameResolver(),

--- a/CustomizeVSWindowTitle/Properties/Resources.Designer.cs
+++ b/CustomizeVSWindowTitle/Properties/Resources.Designer.cs
@@ -373,6 +373,24 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Startup project(s) name(s), separated with &apos; &amp; &apos; if multiple, with the relative path stripped out..
+        /// </summary>
+        internal static string tag_startupProjectsNamesNonRelative {
+            get {
+                return ResourceManager.GetString("tag_startupProjectsNamesNonRelative", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Startup project(s) name(s), separated with X if multiple, with the relative path stripped out. Do not use &apos;[&apos;, &apos;]&apos;, &apos;-&apos;, or &apos;:&apos; for X to avoid parsing conflicts. Recommended values: &apos; &amp; &apos;, &apos;, &apos; or &apos; | &apos; (without quotes)..
+        /// </summary>
+        internal static string tag_startupProjectsNamesNonRelativeX {
+            get {
+                return ResourceManager.GetString("tag_startupProjectsNamesNonRelativeX", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Startup project(s) name(s), separated with X if multiple. Do not use &apos;[&apos;, &apos;]&apos;, &apos;-&apos;, or &apos;:&apos; for X to avoid parsing conflicts. Recommended values: &apos; &amp; &apos;, &apos;, &apos; or &apos; | &apos; (without quotes)..
         /// </summary>
         internal static string tag_startupProjectsNamesX {

--- a/CustomizeVSWindowTitle/Properties/Resources.resx
+++ b/CustomizeVSWindowTitle/Properties/Resources.resx
@@ -205,6 +205,12 @@
   <data name="tag_startupProjectsNamesX" xml:space="preserve">
     <value>Startup project(s) name(s), separated with X if multiple. Do not use '[', ']', '-', or ':' for X to avoid parsing conflicts. Recommended values: ' &amp; ', ', ' or ' | ' (without quotes).</value>
   </data>
+  <data name="tag_startupProjectsNamesNonRelative" xml:space="preserve">
+    <value>Startup project(s) name(s), separated with ' &amp; ' if multiple, with the relative path stripped out.</value>
+  </data>
+  <data name="tag_startupProjectsNamesNonRelativeX" xml:space="preserve">
+    <value>Startup project(s) name(s), separated with X if multiple, with the relative path stripped out. Do not use '[', ']', '-', or ':' for X to avoid parsing conflicts. Recommended values: ' &amp; ', ', ' or ' | ' (without quotes).</value>
+  </data>
   <data name="tag_svnDirectoryName" xml:space="preserve">
     <value>Current SVN directory name. Make sure SVN's executable directory is added to the Windows PATH variable or specify its location in settings.</value>
   </data>

--- a/CustomizeVSWindowTitle/Resolvers/SolutionResolver.cs
+++ b/CustomizeVSWindowTitle/Resolvers/SolutionResolver.cs
@@ -20,12 +20,14 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
     }
 
     public class StartupProjectNamesResolver : TagResolver, ISimpleTagResolver {
-        public StartupProjectNamesResolver() : base(tagNames: new[] { "startupProjectsNames", "startupProjectsNames:X" }) { }
+        public StartupProjectNamesResolver() : this(tagNames: new[] { "startupProjectsNames", "startupProjectsNames:X" }) { }
+        public StartupProjectNamesResolver(IEnumerable<string> tagNames) : base(tagNames: tagNames) { }
 
-        public string TagName { get; } = "startupProjectsNames";
+
+        public virtual string TagName { get; } = "startupProjectsNames";
         static readonly Regex StartupProjectsXRegex = new Regex(@"^startupProjectsNames:(.+)$", RegexOptions.Compiled);
 
-        public string Resolve(AvailableInfo info) {
+        public virtual string Resolve(AvailableInfo info) {
             return string.Join(" & ", GetStartupProjectNames());
         }
 
@@ -40,22 +42,56 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
             return true;
         }
 
-        private static List<string> GetStartupProjectNames() {
+        protected static List<string> GetStartupProjectNames() {
             var sb = (SolutionBuild2)Globals.DTE.Solution.SolutionBuild;
             var names = new List<string>(((Array)sb.StartupProjects).Length);
             foreach (string item in (Array)sb.StartupProjects) {
-                string modifiedItem = item;
-
-                // Strip out folder path so we end up with just the project name
-                int index = modifiedItem.LastIndexOf("\\");
-                if (index > 0) {
-                    modifiedItem = modifiedItem.Substring(index + 1);
-                }
-				
                 //names.Add(Globals.DTE.Solution.Item(item).Name); // Does not work if project is nested in solution folder as only the solution folder is part of the Solution.Projects collection. 
                 //If project name is not always equal to project filename, replace with solution here: https://stackoverflow.com/questions/38740773/how-to-get-project-inside-of-solution-folder-in-vsix-project
                 names.Add(item.Substring(0, item.Length - Path.GetExtension(item).Length));
             }
+            return names;
+        }
+    }
+
+    public class StartupProjectNamesNonRelativeResolver : StartupProjectNamesResolver {
+        public StartupProjectNamesNonRelativeResolver() : base(tagNames: new[] { "startupProjectsNamesNonRelative", "startupProjectsNamesNonRelative:X" }) { }
+
+        public override string TagName { get; } = "startupProjectsNamesNonRelative";
+        static readonly Regex StartupProjectsXRegex = new Regex(@"^startupProjectsNamesNonRelative:(.+)$", RegexOptions.Compiled);
+
+        public override string Resolve(AvailableInfo info)
+        {
+            return string.Join(" & ", GetStartupProjectNamesNonRelative());
+        }
+
+        public override bool TryResolve(string tag, AvailableInfo availableInfo, out string s)
+        {
+            var m = StartupProjectsXRegex.Match(tag);
+            if (!m.Success)
+            {
+                s = null;
+                return false;
+            }
+
+            s = string.Join(m.Groups[1].Value, GetStartupProjectNamesNonRelative());
+            return true;
+        }
+
+        private static List<string> GetStartupProjectNamesNonRelative() {
+            var names = GetStartupProjectNames();
+
+            for (var i = 0; i < names.Count; i++) {
+                string modifiedName = names[i];
+                // Strip out folder path so we end up with just the project name
+                int index = modifiedName.LastIndexOf("\\");
+                if (index > 0) {
+                    modifiedName = modifiedName.Substring(index + 1);
+                }
+
+                names[i] = modifiedName;
+            }
+
             return names;
         }
     }

--- a/CustomizeVSWindowTitle/Resolvers/SolutionResolver.cs
+++ b/CustomizeVSWindowTitle/Resolvers/SolutionResolver.cs
@@ -44,6 +44,14 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
             var sb = (SolutionBuild2)Globals.DTE.Solution.SolutionBuild;
             var names = new List<string>(((Array)sb.StartupProjects).Length);
             foreach (string item in (Array)sb.StartupProjects) {
+                string modifiedItem = item;
+
+                // Strip out folder path so we end up with just the project name
+                int index = modifiedItem.LastIndexOf("\\");
+                if (index > 0) {
+                    modifiedItem = modifiedItem.Substring(index + 1);
+                }
+				
                 //names.Add(Globals.DTE.Solution.Item(item).Name); // Does not work if project is nested in solution folder as only the solution folder is part of the Solution.Projects collection. 
                 //If project name is not always equal to project filename, replace with solution here: https://stackoverflow.com/questions/38740773/how-to-get-project-inside-of-solution-folder-in-vsix-project
                 names.Add(item.Substring(0, item.Length - Path.GetExtension(item).Length));


### PR DESCRIPTION
…name if it is present.

UE4 example:
"Intermediate\ProjectFiles\MyGame.vcxproj" will now become "MyGame" instead of "Intermediate\ProjectFiles\MyGame".