### PR TITLE
Added DocumentDirtyResolver

### DIFF
--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
@@ -51,6 +51,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new StartupProjectNamesNonRelativeResolver(),
                 new DocumentProjectNameResolver(),
                 new DocumentProjectFileNameResolver(),
+                new DocumentDirtyResolver(),
                 new SolutionNameResolver(),
                 new DocumentPathResolver(),
                 new DocumentParentPathResolver(),
@@ -71,8 +72,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new VsProcessIdResolver(),
                 new EnvResolver(),
                 new DebuggedProcessesArgsResolver(),
-                new TfsBranchNameResolver(),
-                new DocumentDirtyResolver()
+                new TfsBranchNameResolver()
             };
             this.SupportedTags = this.TagResolvers.SelectMany(r => r.TagNames).ToArray();
             this.SimpleTagResolvers = this.TagResolvers.OfType<ISimpleTagResolver>().ToDictionary(t => t.TagName, t => t);

--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
@@ -71,7 +71,8 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new VsProcessIdResolver(),
                 new EnvResolver(),
                 new DebuggedProcessesArgsResolver(),
-                new TfsBranchNameResolver()
+                new TfsBranchNameResolver(),
+                new DirtyResolver()
             };
             this.SupportedTags = this.TagResolvers.SelectMany(r => r.TagNames).ToArray();
             this.SimpleTagResolvers = this.TagResolvers.OfType<ISimpleTagResolver>().ToDictionary(t => t.TagName, t => t);

--- a/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitle/CustomizeVSWindowTitlePackage.cs
@@ -72,7 +72,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new EnvResolver(),
                 new DebuggedProcessesArgsResolver(),
                 new TfsBranchNameResolver(),
-                new DirtyResolver()
+                new DocumentDirtyResolver()
             };
             this.SupportedTags = this.TagResolvers.SelectMany(r => r.TagNames).ToArray();
             this.SimpleTagResolvers = this.TagResolvers.OfType<ISimpleTagResolver>().ToDictionary(t => t.TagName, t => t);

--- a/CustomizeVSWindowTitle/Resolvers/DocumentResolver.cs
+++ b/CustomizeVSWindowTitle/Resolvers/DocumentResolver.cs
@@ -133,4 +133,13 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
             return DocumentHelper.GetActiveDocumentProjectNameOrEmpty(activeDocument: info.ActiveDocument);
         }
     }
+
+    public class DocumentDirtyResolver : SimpleTagResolver
+    {
+        public DocumentDirtyResolver() : base(tagName: "documentDirty") { }
+        public override string Resolve(AvailableInfo info)
+        {
+            return (info.ActiveDocument.Saved ? "" : "[*]");
+        }
+    }
 }


### PR DESCRIPTION
This is similar to an open item, but not quite the same
https://github.com/mayerwin/vs-customize-window-title/issues/24

This only applies to the active document. I wasn't sure what to put for the output. A * seems to be common in other editors (and the tabs in VS itself), but It seems like VS forces a * in the title for it's own reasons and I wanted to avoid confusion. I tried to make it configurable like documentDirty:* or documentDirty:[*], but I couldn't figure that out. I hard coded [*].
I don't presume to suggest that this is great or whatever. I have never contributed to an open source project, so I'm not sure if I'm doing it correctly. I'm just really enthused that this cool extension exists, it's done so incredibly well, documented like a dream, written so nicely that it was super easy to extend, and I have a chance to contribute.
Thanks!