### PR TITLE
ADDED | Added new DebuggedProcessesExesResolver

### DIFF
--- a/CustomizeVSWindowTitleShared/CustomizeVSWindowTitlePackage.cs
+++ b/CustomizeVSWindowTitleShared/CustomizeVSWindowTitlePackage.cs
@@ -83,6 +83,7 @@ namespace ErwinMayerLabs.RenameVSWindowTitle {
                 new VsProcessIdResolver(),
                 new EnvResolver(),
                 new DebuggedProcessesArgsResolver(),
+				new DebuggedProcessesExesResolver(),
                 new TfsBranchNameResolver()
             };
             this.SupportedTags = this.TagResolvers.SelectMany(r => r.TagNames).ToArray();

--- a/CustomizeVSWindowTitleShared/CustomizeVSWindowTitleShared.projitems
+++ b/CustomizeVSWindowTitleShared/CustomizeVSWindowTitleShared.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\AnythingUnsavedResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\ConfigurationResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\DebuggedProcessesArgsResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Resolvers\DebuggedProcessesExesResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\DocumentResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\ElevationSuffixResolver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resolvers\GitResolver.cs" />

--- a/CustomizeVSWindowTitleShared/Resolvers/DebuggedProcessesExesResolver.cs
+++ b/CustomizeVSWindowTitleShared/Resolvers/DebuggedProcessesExesResolver.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management;
+using EnvDTE80;
+
+namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers
+{
+    public class DebuggedProcessesExesResolver : SimpleTagResolver
+    {
+        public DebuggedProcessesExesResolver() : base(tagName: "debuggedProcessesExes") { }
+
+        public override string Resolve(AvailableInfo info)
+        {
+            var list = new List<Tuple<string, string>>();
+            // var process = Globals.DTE.Debugger.CurrentProcess; returns null for some reason.
+            foreach (Process2 process in Globals.DTE.Debugger.DebuggedProcesses)
+            {
+                if (GetCommandLine(process, out var executablePath, out var args))
+                {
+                    list.Add(Tuple.Create(executablePath, args));
+                }
+            }
+            return !list.Any() ? "" : string.Join(" & ", list.Select(e => Path.GetFileName(e.Item1) + " " + e.Item2));
+        }
+
+        // Define an extension method for type System.Process that returns the command 
+        // line via WMI.
+        private static bool GetCommandLine(Process2 process, out string executablePath, out string args)
+        {
+            executablePath = "";
+            args = "";
+            if (process == null) return false;
+            string cmdLine = null;
+            using (var searcher = new ManagementObjectSearcher(
+                $"SELECT CommandLine,ExecutablePath FROM Win32_Process WHERE ProcessId = {process.ProcessID}"))
+            {
+                // By definition, the query returns at most 1 match, because the process 
+                // is looked up by ID (which is unique by definition).
+                var matchEnum = searcher.Get().GetEnumerator();
+                if (matchEnum.MoveNext()) // Move to the 1st item.
+                {
+                    cmdLine = matchEnum.Current["CommandLine"]?.ToString();
+                    executablePath = matchEnum.Current["ExecutablePath"]?.ToString();
+                }
+            }
+            if (cmdLine == null || executablePath == null)
+            {
+                // Not having found a command line implies 1 of 2 exceptions, which the
+                // WMI query masked:
+                // An "Access denied" exception due to lack of privileges.
+                // A "Cannot process request because the process (<pid>) has exited."
+                // exception due to the process having terminated.
+                // We provoke the same exception again simply by accessing process.MainModule.
+                //var dummy = process.MainModule; // Provoke exception.
+                return false;
+            }
+            args = cmdLine.Replace("\"" + executablePath + "\" ", "");
+            return true;
+        }
+    }
+}

--- a/CustomizeVSWindowTitleSharedResources/Properties/Resources.Designer.cs
+++ b/CustomizeVSWindowTitleSharedResources/Properties/Resources.Designer.cs
@@ -175,6 +175,15 @@ namespace ErwinMayerLabs.CustomizeVSWindowTitleSharedResources.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Names and arguments of the processes currently being debugged.
+        /// </summary>
+        public static string tag_debuggedProcessesExes {
+            get {
+                return ResourceManager.GetString("tag_debuggedProcessesExes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Active document or, if no active document, window name..
         /// </summary>
         public static string tag_documentName {

--- a/CustomizeVSWindowTitleSharedResources/Properties/Resources.resx
+++ b/CustomizeVSWindowTitleSharedResources/Properties/Resources.resx
@@ -136,6 +136,9 @@
   <data name="tag_debuggedProcessesArgs" xml:space="preserve">
     <value>Arguments of the processes currently debugged (including the executable file name before each set of arguments if more than 1 process).</value>
   </data>
+  <data name="tag_debuggedProcessesExes" xml:space="preserve">
+    <value>Names and arguments of the processes currently being debugged</value>
+  </data>
   <data name="tag_documentName" xml:space="preserve">
     <value>Active document or, if no active document, window name.</value>
   </data>


### PR DESCRIPTION
This is a new resolver to always show the process names being debugged along with their arguments

I find this useful as I have multiple executable projects in my solution, and right click start new instance

Displaying the process name in the title bar is an easy way for me to remember which is running 