### PR TITLE
Fix for ProjectName issue

### DIFF
--- a/CustomizeVSWindowTitleShared/Resolvers/ProjectResolver.cs
+++ b/CustomizeVSWindowTitleShared/Resolvers/ProjectResolver.cs
@@ -7,6 +7,13 @@ namespace ErwinMayerLabs.RenameVSWindowTitle.Resolvers {
         public static bool TryGetActiveProject(DTE2 dte, out Project activeProject) {
             activeProject = null;
             try {
+                // Get the project of the current displayed document
+                var activeDocument = dte.ActiveDocument;
+                if (activeDocument != null && activeDocument.ProjectItem != null && activeDocument.ProjectItem.ContainingProject != null) {
+                    activeProject = activeDocument.ProjectItem.ContainingProject;
+                    return true;
+                }
+
                 var activeSolutionProjects = dte.ActiveSolutionProjects as Array;
                 if (activeSolutionProjects != null && activeSolutionProjects.Length > 0) {
                     activeProject = activeSolutionProjects.GetValue(0) as Project;


### PR DESCRIPTION
Get the project of the currently displayed document instead of the active project (in solution explorer)